### PR TITLE
Add Unittest for PEP 695 generics syntax

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,4 +20,7 @@ jobs:
           pip install tox
       - name: Run the Unit Tests via Tox
         run: |
-          tox -e tests
+          TOXENV=py${{ matrix.python-version }}-tests
+          TOXENV=${TOXENV//.}
+          echo "Running the unit tests via Tox with the environment $TOXENV"
+          tox -e $TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    tests
+    py311-tests
+    py312-tests
     linting
     coverage
     type_check
@@ -10,18 +11,27 @@ skipsdist = True
 [testenv]
 commands = python -m pip install --upgrade pip
 
-[testenv:tests]
+[testenv:py312-tests]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     -r requirements.txt
     -r dev_requirements/requirements-tests.txt
 setenv = PYTHONPATH = {toxinidir}/src
-commands = python -m pytest --basetemp={envtmpdir} {posargs}
+commands =
+    python -m pytest --basetemp={envtmpdir} {posargs}
+
+[testenv:py311-tests]
+# the tests environment is called by the Github action that runs the unit tests
+deps =
+    {[testenv:py312-tests]deps}
+setenv = PYTHONPATH = {toxinidir}/src
+commands =
+    python -m pytest --basetemp={envtmpdir} --ignore=unittests/test_py_312.py {posargs}
 
 [testenv:linting]
 # the linting environment is called by the Github Action that runs the linter
 deps =
-    {[testenv:tests]deps}
+    {[testenv:py312-tests]deps}
     -r dev_requirements/requirements-linting.txt
     # add your fixtures like e.g. pytest_datafiles here
 setenv = PYTHONPATH = {toxinidir}/src
@@ -34,7 +44,7 @@ commands =
 # the type_check environment checks the type hints using mypy
 setenv = PYTHONPATH = {toxinidir}/src
 deps =
-    {[testenv:tests]deps}
+    {[testenv:py312-tests]deps}
     -r dev_requirements/requirements-type_check.txt
 commands =
     mypy --show-error-codes src/generics
@@ -45,7 +55,7 @@ commands =
 # the coverage environment is called by the Github Action that runs the coverage measurement
 changedir = unittests
 deps =
-    {[testenv:tests]deps}
+    {[testenv:py312-tests]deps}
     -r dev_requirements/requirements-coverage.txt
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
@@ -57,7 +67,7 @@ commands =
 [testenv:dev]
 # the dev environment contains everything you need to start developing on your local machine.
 deps =
-    {[testenv:tests]deps}
+    {[testenv:py312-tests]deps}
     {[testenv:linting]deps}
     {[testenv:type_check]deps}
     {[testenv:coverage]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     -r dev_requirements/requirements-type_check.txt
 commands =
     mypy --show-error-codes src/generics
-    mypy --show-error-codes unittests
+    mypy --show-error-codes --enable-incomplete-feature=NewGenericSyntax unittests
     # add single files (ending with .py) or packages here
 
 [testenv:coverage]

--- a/unittests/test_get_filled_type.py
+++ b/unittests/test_get_filled_type.py
@@ -276,3 +276,23 @@ class TestGetFilledType:
         """
         assert get_filled_type(dict[str, int], dict, 1) is int
         assert get_filled_type(dict[str, int], dict, 0) is str
+
+    def test_pep695_generics(self):
+        """
+        Test `get_filled_type` with PEP 695 generics syntax.
+        https://peps.python.org/pep-0695/
+        """
+
+        class A[T]:
+            pass
+
+        class B[T](A[T]):
+            pass
+
+        class C[T]:
+            pass
+
+        class D[U, Z](B[Z], C[int], List[U]):
+            pass
+
+        assert get_filled_type(D[int, str], A, 0) is str

--- a/unittests/test_get_filled_type.py
+++ b/unittests/test_get_filled_type.py
@@ -276,23 +276,3 @@ class TestGetFilledType:
         """
         assert get_filled_type(dict[str, int], dict, 1) is int
         assert get_filled_type(dict[str, int], dict, 0) is str
-
-    def test_pep695_generics(self):
-        """
-        Test `get_filled_type` with PEP 695 generics syntax.
-        https://peps.python.org/pep-0695/
-        """
-
-        class A[T]:
-            pass
-
-        class B[T](A[T]):
-            pass
-
-        class C[T]:
-            pass
-
-        class D[U, Z](B[Z], C[int], List[U]):
-            pass
-
-        assert get_filled_type(D[int, str], A, 0) is str

--- a/unittests/test_py_312.py
+++ b/unittests/test_py_312.py
@@ -1,0 +1,31 @@
+"""
+Tests for Python 3.12 features.
+"""
+
+from generics import get_filled_type
+
+
+class TestPy312:
+    """
+    Tests for Python 3.12 features
+    """
+
+    def test_get_filled_type_with_pep695_generics(self):
+        """
+        Test `get_filled_type` with PEP 695 generics syntax.
+        https://peps.python.org/pep-0695/
+        """
+
+        class A[T]:
+            pass
+
+        class B[T](A[T]):
+            pass
+
+        class C[T]:
+            pass
+
+        class D[U, Z](B[Z], C[int], list[U]):
+            pass
+
+        assert get_filled_type(D[int, str], A, 0) is str

--- a/unittests/test_py_312.py
+++ b/unittests/test_py_312.py
@@ -32,3 +32,6 @@ class TestPy312:
             pass
 
         assert get_filled_type(D[int, str], A, 0) is str
+        assert get_filled_type(D[int, str], B, 0) is str
+        assert get_filled_type(D[int, str], C, 0) is int
+        assert get_filled_type(D[int, str], list, 0) is int

--- a/unittests/test_py_312.py
+++ b/unittests/test_py_312.py
@@ -19,6 +19,9 @@ class TestPy312:
         class A[T]:
             pass
 
+        # pylint: disable=undefined-variable
+        # Issue: https://github.com/pylint-dev/pylint/issues/9335#issuecomment-2245388198
+
         class B[T](A[T]):
             pass
 


### PR DESCRIPTION
Apparently, this project works with the new syntax out of the box. Added a unittest for this.
Resolves #94