### PR TITLE
chore(python): Officially support Python 3.9

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,7 @@ jobs:
           pip install tox
       - name: Run the Unit Tests via Tox
         run: |
-          TOXENV=py${{ matrix.python-version }}-tests
+          TOXENV=tests-py${{ matrix.python-version }}
           TOXENV=${TOXENV//.}
           echo "Running the unit tests via Tox with the environment $TOXENV"
           tox -e $TOXENV

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,9 @@ jobs:
           pip install tox
       - name: Run the Unit Tests via Tox
         run: |
-          TOXENV=py${{ matrix.python-version }}-tests
-          TOXENV=${TOXENV//.}
+          if [ "${{ matrix.python-version }}" < "3.12" ]; then
+            TOXENV=py311-tests
+          else
+            TOXENV=py312-tests
           echo "Running the unit tests via Tox with the environment $TOXENV"
           tox -e $TOXENV

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,5 +24,6 @@ jobs:
             TOXENV=py312-tests
           else
             TOXENV=py311-tests
+            fi
           echo "Running the unit tests via Tox with the environment $TOXENV"
           tox -e $TOXENV

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,10 +20,7 @@ jobs:
           pip install tox
       - name: Run the Unit Tests via Tox
         run: |
-          if [ "${{ matrix.python-version }}" = "3.12" ]; then
-            TOXENV=py312-tests
-          else
-            TOXENV=py311-tests
-            fi
+          TOXENV=py${{ matrix.python-version }}-tests
+          TOXENV=${TOXENV//.}
           echo "Running the unit tests via Tox with the environment $TOXENV"
           tox -e $TOXENV

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,9 +20,9 @@ jobs:
           pip install tox
       - name: Run the Unit Tests via Tox
         run: |
-          if [ "${{ matrix.python-version }}" < "3.12" ]; then
-            TOXENV=py311-tests
-          else
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
             TOXENV=py312-tests
+          else
+            TOXENV=py311-tests
           echo "Running the unit tests via Tox with the environment $TOXENV"
           tox -e $TOXENV

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-generics"
 description = "A package to determine the values of generic classes through instances or subclasses "
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 authors = [{ name = "Hochfrequenz Unternehmensberatung GmbH", email = "info@hochfrequenz.de" }]
 keywords = ["python", "generics"]
 classifiers = [
@@ -13,6 +13,9 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "python-generics"
 description = "A package to determine the values of generic classes through instances or subclasses "
 license = { text = "MIT" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [{ name = "Hochfrequenz Unternehmensberatung GmbH", email = "info@hochfrequenz.de" }]
 keywords = ["python", "generics"]
 classifiers = [
@@ -13,8 +13,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ Homepage = "https://github.com/Hochfrequenz/python-generics"
 
 [tool.black]
 line-length = 120
+target_version = ["py39", "py310", "py311", "py312"]
 
 [tool.isort]
 line_length = 120

--- a/src/generics/__init__.py
+++ b/src/generics/__init__.py
@@ -57,14 +57,14 @@ def get_type_vars(type_: Union[type, GenericType]) -> tuple[TypeVar, ...]:
     if not _generic_metaclass_executed_on_type(type_):
         return ()
 
-    for base in type_.__orig_bases__:
+    for base in type_.__orig_bases__:  # type: ignore[union-attr]
         if get_origin(base) is Generic:
             return get_args(base)
 
     # if we get here, the type has not `Generic` directly as supertype. Therefore, collect the type variables from
     # all the supertypes arguments.
     type_vars: list[TypeVar] = []
-    for base in type_.__orig_bases__:
+    for base in type_.__orig_bases__:  # type: ignore[union-attr]
         if isinstance(base, (TypingGenericAlias, TypesGenericAlias)):
             for arg in get_args(base):
                 if isinstance(arg, TypeVar) and arg not in type_vars:
@@ -187,7 +187,7 @@ def get_filled_type(
             continue
         if not _generic_metaclass_executed_on_type(type_):
             raise TypeError(f"Could not determine the type in {filled_type!r}: {type_!r} is not generic")
-        for orig_base in type_.__orig_bases__:
+        for orig_base in type_.__orig_bases__:  # type: ignore[attr-defined]
             if get_origin(orig_base) == type_trace[-reversed_index + 1]:
                 orig_base_args = get_args(orig_base)
                 if len(orig_base_args) < type_var_index:

--- a/src/generics/__init__.py
+++ b/src/generics/__init__.py
@@ -8,7 +8,7 @@ is no need to support this edge case.
 
 from typing import Any, Generic
 from typing import GenericAlias as TypesGenericAlias  # type: ignore[attr-defined]
-from typing import Optional, Protocol, TypeGuard, TypeVar
+from typing import Optional, Protocol, TypeVar
 from typing import _GenericAlias as TypingGenericAlias  # type: ignore[attr-defined]
 from typing import get_args, get_origin
 
@@ -73,7 +73,7 @@ def get_type_vars(type_: type | GenericType) -> tuple[TypeVar, ...]:
     return tuple(type_vars)
 
 
-def _generic_metaclass_executed_on_type(type_: type | GenericType) -> TypeGuard[GenericType]:
+def _generic_metaclass_executed_on_type(type_: type | GenericType) -> bool:
     """
     This function determines if the type was processed by a `_GenericAlias` with all its `__mro_entries__` magic.
     I.e. if the type has `Generic` as supertype or something like `A[T]` in its supertypes.

--- a/src/generics/__init__.py
+++ b/src/generics/__init__.py
@@ -6,7 +6,7 @@ will not work. This is because these "primitive" types are different from "norma
 is no need to support this edge case.
 """
 
-from typing import Any, Generic
+from typing import Any, Generic, Union
 from typing import GenericAlias as TypesGenericAlias  # type: ignore[attr-defined]
 from typing import Optional, Protocol, TypeVar
 from typing import _GenericAlias as TypingGenericAlias  # type: ignore[attr-defined]
@@ -22,7 +22,7 @@ class GenericType(Protocol):
     __orig_bases__: tuple[type, ...]
 
 
-def get_type_vars(type_: type | GenericType) -> tuple[TypeVar, ...]:
+def get_type_vars(type_: Union[type, GenericType]) -> tuple[TypeVar, ...]:
     """
     For a given generic type, return a tuple of its type variables. The type variables are collected through the
     supertypes arguments `Generic` if present.
@@ -73,7 +73,7 @@ def get_type_vars(type_: type | GenericType) -> tuple[TypeVar, ...]:
     return tuple(type_vars)
 
 
-def _generic_metaclass_executed_on_type(type_: type | GenericType) -> bool:
+def _generic_metaclass_executed_on_type(type_: Union[type, GenericType]) -> bool:
     """
     This function determines if the type was processed by a `_GenericAlias` with all its `__mro_entries__` magic.
     I.e. if the type has `Generic` as supertype or something like `A[T]` in its supertypes.
@@ -111,7 +111,7 @@ def _find_super_type_trace(type_: type, search_for_type: type) -> Optional[list[
 
 
 def _process_inputs_of_get_filled_type(
-    type_or_instance: Any, type_var_defining_super_type: type, type_var_or_position: TypeVar | int
+    type_or_instance: Any, type_var_defining_super_type: type, type_var_or_position: Union[TypeVar, int]
 ) -> tuple[type, type, int]:
     """
     This function processes the inputs of `get_filled_type`. It returns a tuple of the filled type, the super type and
@@ -142,7 +142,7 @@ def _process_inputs_of_get_filled_type(
 
 # pylint: disable=too-many-branches, too-many-locals
 def get_filled_type(
-    type_or_instance: Any, type_var_defining_super_type: type, type_var_or_position: TypeVar | int
+    type_or_instance: Any, type_var_defining_super_type: type, type_var_or_position: Union[TypeVar, int]
 ) -> Any:
     """
     Determines the type of the `type_var_or_position` defined by the type `type_var_defining_super_type`.

--- a/src/generics/__init__.py
+++ b/src/generics/__init__.py
@@ -6,9 +6,9 @@ will not work. This is because these "primitive" types are different from "norma
 is no need to support this edge case.
 """
 
-from typing import Any, Generic, Union
+from typing import Any, Generic
 from typing import GenericAlias as TypesGenericAlias  # type: ignore[attr-defined]
-from typing import Optional, Protocol, TypeVar
+from typing import Optional, Protocol, TypeVar, Union
 from typing import _GenericAlias as TypingGenericAlias  # type: ignore[attr-defined]
 from typing import get_args, get_origin
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
 [testenv:linting]
 # the linting environment is called by the Github Action that runs the linter
 deps =
-    {[testenv:py312-tests]deps}
+    {[testenv:tests-py12]deps}
     -r dev_requirements/requirements-linting.txt
     # add your fixtures like e.g. pytest_datafiles here
 setenv = PYTHONPATH = {toxinidir}/src
@@ -44,7 +44,7 @@ commands =
 # the type_check environment checks the type hints using mypy
 setenv = PYTHONPATH = {toxinidir}/src
 deps =
-    {[testenv:py312-tests]deps}
+    {[testenv:tests-py12]deps}
     -r dev_requirements/requirements-type_check.txt
 commands =
     mypy --show-error-codes src/generics
@@ -55,7 +55,7 @@ commands =
 # the coverage environment is called by the Github Action that runs the coverage measurement
 changedir = unittests
 deps =
-    {[testenv:py312-tests]deps}
+    {[testenv:tests-py12]deps}
     -r dev_requirements/requirements-coverage.txt
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
@@ -67,7 +67,7 @@ commands =
 [testenv:dev]
 # the dev environment contains everything you need to start developing on your local machine.
 deps =
-    {[testenv:py312-tests]deps}
+    {[testenv:tests-py12]deps}
     {[testenv:linting]deps}
     {[testenv:type_check]deps}
     {[testenv:coverage]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py37,py38,py39,py310,py311,py312}-tests
+    tests-py{37,38,39,310,311,312}
     linting
     coverage
     type_check
@@ -10,7 +10,7 @@ skipsdist = True
 [testenv]
 commands = python -m pip install --upgrade pip
 
-[testenv:py312-tests]
+[testenv:tests-py312]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     -r requirements.txt
@@ -19,10 +19,11 @@ setenv = PYTHONPATH = {toxinidir}/src
 commands =
     python -m pytest --basetemp={envtmpdir} {posargs}
 
-[testenv:tests]
+[testenv:tests-py{37,38,39,310,311,312}]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
-    {[testenv:py312-tests]deps}
+    -r requirements.txt
+    -r dev_requirements/requirements-tests.txt
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
     python -m pytest --basetemp={envtmpdir} --ignore=unittests/test_py_312.py {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 commands =
     python -m pytest --basetemp={envtmpdir} {posargs}
 
-[testenv:tests-py{37,38,39,310,311,312}]
+[testenv:tests-py{37,38,39,310,311}]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    tests-py{37,38,39,310,311,312}
+    tests-py{39,310,311,312}
     linting
     coverage
     type_check
@@ -19,7 +19,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 commands =
     python -m pytest --basetemp={envtmpdir} {posargs}
 
-[testenv:tests-py{37,38,39,310,311}]
+[testenv:tests-py{39,310,311}]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py311-tests
-    py312-tests
+    {py37,py38,py39,py310,py311,py312}-tests
     linting
     coverage
     type_check
@@ -20,7 +19,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 commands =
     python -m pytest --basetemp={envtmpdir} {posargs}
 
-[testenv:py311-tests]
+[testenv:tests]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     {[testenv:py312-tests]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
 [testenv:linting]
 # the linting environment is called by the Github Action that runs the linter
 deps =
-    {[testenv:tests-py12]deps}
+    {[testenv:tests-py312]deps}
     -r dev_requirements/requirements-linting.txt
     # add your fixtures like e.g. pytest_datafiles here
 setenv = PYTHONPATH = {toxinidir}/src
@@ -44,7 +44,7 @@ commands =
 # the type_check environment checks the type hints using mypy
 setenv = PYTHONPATH = {toxinidir}/src
 deps =
-    {[testenv:tests-py12]deps}
+    {[testenv:tests-py312]deps}
     -r dev_requirements/requirements-type_check.txt
 commands =
     mypy --show-error-codes src/generics
@@ -55,7 +55,7 @@ commands =
 # the coverage environment is called by the Github Action that runs the coverage measurement
 changedir = unittests
 deps =
-    {[testenv:tests-py12]deps}
+    {[testenv:tests-py312]deps}
     -r dev_requirements/requirements-coverage.txt
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
@@ -67,7 +67,7 @@ commands =
 [testenv:dev]
 # the dev environment contains everything you need to start developing on your local machine.
 deps =
-    {[testenv:tests-py12]deps}
+    {[testenv:tests-py312]deps}
     {[testenv:linting]deps}
     {[testenv:type_check]deps}
     {[testenv:coverage]deps}


### PR DESCRIPTION
Below Python3.7 GH Actions seem to have problems finding those Python versions for the Ubuntu version in use. I think 3.7 is more than enough though.