### PR TITLE
test: 💚Add tox env for Python 3.13 unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skipsdist = True
 [testenv]
 commands = python -m pip install --upgrade pip
 
-[testenv:tests-py312]
+[testenv:tests-py{312,313}]
 # the tests environment is called by the Github action that runs the unit tests
 deps =
     -r requirements.txt


### PR DESCRIPTION
Previously, the workflow doesn't fail for Python 3.13 but it also doesn't execute the tests.